### PR TITLE
[] Fix cancellable async task flow.

### DIFF
--- a/Tests/DysonTests/RequestTests.swift
+++ b/Tests/DysonTests/RequestTests.swift
@@ -36,7 +36,7 @@ final class RequestTests: XCTestCase {
         let request = try sut(url: URL(string: "http://127.0.0.1:8080")!)
         
         // Then
-        XCTAssertEqual(request.url?.query(), "name=dyson")
+        XCTAssertEqual(request.url?.query, "name=dyson")
     }
     
     func test_that_body_request_make_URLRequest_from_the_url_with_data() async throws {

--- a/Tests/DysonTests/SpecTests.swift
+++ b/Tests/DysonTests/SpecTests.swift
@@ -145,7 +145,7 @@ final class SpecTests: XCTestCase {
         let _ = try await request(
             spec: sut,
             dataTask: { request, completion in
-                XCTAssertEqual(request.url?.query(), "name=dyson")
+                XCTAssertEqual(request.url?.query, "name=dyson")
                 
                 completion(.success((Data(), .http(request, status: 200))))
             }


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.



# 🔥 Cause
> If there is a reason, write why the code changes was occurred.

In the test codes, the mock provider processes all codes synchronously. So in the codes to make cancellable task, not call continuations because the completion handler was called before assigning the continuation value.

# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

- Fix cancellable flow to add `CancellableTask` actor.
  - The `SessionTask` is wrapped by `CancellableTask` and process in actor-isolated.
- Minor fixes: `URL`'s `query()` method supports over iOS 16.0, it changed to `query`.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.


