### PR TITLE
[] Change `Dyson`'s responser parameter to optional.

### DIFF
--- a/Sources/Dyson/Dyson+Async.swift
+++ b/Sources/Dyson/Dyson+Async.swift
@@ -65,6 +65,7 @@ public extension Dyson {
     @discardableResult
     func data<S: Spec>(
         _ spec: S,
+        responser: (any Responser)? = nil,
         progress: ((Progress) -> Void)? = nil,
         requestModifier: ((URLRequest) -> URLRequest)? = nil
     ) async throws -> S.Result {
@@ -76,6 +77,7 @@ public extension Dyson {
                     await cancellableTask.perform(
                         data(
                             spec,
+                            responser: responser,
                             progress: progress,
                             requestModifier: requestModifier
                         ) { result in

--- a/Sources/Dyson/Model/DysonError.swift
+++ b/Sources/Dyson/Model/DysonError.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public enum DysonError: Error {
+    case responserNotRegistered
     case invalidURL
     case failedToParse(Error?)
     case failedToLoadData

--- a/Tests/DysonTests/DysonTests.swift
+++ b/Tests/DysonTests/DysonTests.swift
@@ -63,4 +63,87 @@ final class DysonTests: XCTestCase {
         // Then
         XCTAssertEqual(response, person)
     }
+    
+    func test_that_dyson_throw_error_when_response_data_without_responser() async throws {
+        // Give
+        let person = Person(name: "dyson")
+        
+        let jsonEncoder = JSONEncoder()
+        let data = try jsonEncoder.encode(person)
+        
+        let sut = Dyson(
+            provider: .mock(
+                dataTask: { request, completion in
+                    completion(.success((data, .http(request, status: 200))))
+                }
+            )
+        )
+        let spec = MockSpec<Empty, Person, Empty>(
+            result: .codable
+        )
+        
+        // When
+        do {
+            try await sut.data(spec)
+            XCTFail()
+        } catch {
+            
+        }
+        
+        // Then
+    }
+    
+    func test_that_dyson_response_data_when_request_with_responser_even_if_responser_not_registered() async throws {
+        // Give
+        let person = Person(name: "dyson")
+        
+        let jsonEncoder = JSONEncoder()
+        let data = try jsonEncoder.encode(person)
+        
+        let sut = Dyson(
+            provider: .mock(
+                dataTask: { request, completion in
+                    completion(.success((data, .http(request, status: 200))))
+                }
+            )
+        )
+        let spec = MockSpec<Empty, Person, Empty>(
+            result: .codable
+        )
+        
+        // When
+        try await sut.data(spec, responser: .default)
+        
+        // Then
+    }
+    
+    func test_that_dyson_throw_error_when_response_data_even_if_responser_registered() async throws {
+        // Give
+        let person = Person(name: "dyson")
+        
+        let jsonEncoder = JSONEncoder()
+        let data = try jsonEncoder.encode(person)
+        
+        let sut = Dyson(
+            provider: .mock(
+                dataTask: { request, completion in
+                    completion(.success((data, .http(request, status: 200))))
+                }
+            ),
+            responser: .default
+        )
+        let spec = MockSpec<Empty, Person, Empty>(
+            result: .codable
+        )
+        
+        // When
+        do {
+            try await sut.data(spec, responser: .error(TestError(message: "error")))
+            XCTFail()
+        } catch {
+            
+        }
+        
+        // Then
+    }
 }

--- a/Tests/DysonTests/Model/Responser/ErrorResponser.swift
+++ b/Tests/DysonTests/Model/Responser/ErrorResponser.swift
@@ -1,0 +1,35 @@
+//
+//  ErrorResponser.swift
+//
+//
+//  Created by jsilver on 2022/01/23.
+//
+
+import Foundation
+import Dyson
+
+extension Responser {
+    static func error(_ error: any Error) -> Self where Self == ErrorResponser { ErrorResponser(error) }
+}
+
+struct ErrorResponser: Responser {
+    // MARK: - Property
+    private let error: any Error
+    
+    // MARK: - Initializer
+    init(_ error: any Error) {
+        self.error = error
+    }
+    
+    // MARK: - Lifecycle
+    func response<S: Spec>(
+        _ response: Result<(Data, URLResponse), any Error>,
+        spec: S
+    ) throws -> S.Result {
+        throw error
+    }
+    
+    // MARK: - Public
+    
+    // MARK: - Private
+}


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.



# 🔥 Cause
> If there is a reason, write why the code changes was occurred.



# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

- Change `Dyson`'s responser parameter in initializer to optional.
  - If you don't pass any responser to initializer, `Dyson` throw `DysonError.responserNotRegistered` when request `data(_:)`.
- Add responser parameter on `data(_:)`
  ```swift
  dyson.data(SomeSpec(.init()), responser: OneTimeResponser()) { ... }
  ```

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.


