### PR TITLE
[RELEASE] Dyson/2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ dependencies: [
 ```
 
 # Basic Usage
-You should start by creating a `Dyson` object. `Dyson` takes parameters such as `NetworkProvider`, `Responser`, and `Interceptor`, which will be discussed below.
+You should start by creating a `Dyson` object. `Dyson` takes parameters such as `NetworkProvider` and `Interceptor`, which will be discussed below.
 ```swift
 let dyson = Dyson(
     provider: .url(),
-    responser: MyResponser(),
     defaultHeaders: [
         "Content-Type": "application/json"
     ],
@@ -58,6 +57,7 @@ dyson.data(GetInfoSpec(.init())) { result in
     // result's type is Result<GetInfoSpec.Result, any Error>
 }
 ```
+
 ## NetworkProvider
 `NetworkProvider` is the protocol that abstracts the functionality of network communication.
 
@@ -73,7 +73,7 @@ public protocol NetworkProvider {
 `Dyson` serve default network provider, `URLNetworkProvider` that implemented using `URLSession`.
 
 ## Responser
-`Responder` is a protocol that abstracts how to respond to a network response.
+`Responser` is a protocol that abstracts how to respond to a network response.
 
 Responsible for the implementation of how to handle the conventions for network responses between servers and clients.
 
@@ -88,9 +88,10 @@ public protocol Responser {
 
 For example, you might need to filter by a range of status codes with your own communication protocols, or parse response data and header values together.
 
-These characteristics usually depend on the server you're communicating with(just as different OpenAPIs have different communication protocols).
+These characteristics usually depend on the server you're communicating with (just as different OpenAPIs have different communication protocols).
 
-Typically, the implementation of a 'responder' looks like this.
+Typically, the implementation of a 'responser' looks like this.
+
 ```swift
 func response<S: Spec>(
     _ response: Result<(Data, URLResponse), any Error>,
@@ -277,6 +278,7 @@ public protocol Spec {
     var headers: HTTPHeaders { get }
     
     var request: any Request { get }
+    var responser: (any Responser)? { get }
     var result: Mapper<Result> { get }
     var error: Mapper<Error> { get }
 }
@@ -299,6 +301,7 @@ public struct GetInfoSpec: Spec {
             "id": parameter.id
         ])
     }
+    var responser: (any Responser)? { YourServerResponser() }
     var result: Mapper<Result> { .codable }
     var error: Mapper<Error> { .codable }
 
@@ -341,7 +344,7 @@ public protocol Request {
 The `Dyson` serve some requests.
 - none </br>
   Not exist additional process.
-- query(_:) </br>
+- query(_:isEncoded:) </br>
   Add the query parameters as a query to the URL.
 - body(_:encoder:) </br>
   After encoding with the encoder, add the parameters as data to the HTTP body. </br>

--- a/Sources/Dyson/Dyson+Async.swift
+++ b/Sources/Dyson/Dyson+Async.swift
@@ -65,7 +65,6 @@ public extension Dyson {
     @discardableResult
     func data<S: Spec>(
         _ spec: S,
-        responser: (any Responser)? = nil,
         progress: ((Progress) -> Void)? = nil,
         requestModifier: ((URLRequest) -> URLRequest)? = nil
     ) async throws -> S.Result {
@@ -77,7 +76,6 @@ public extension Dyson {
                     await cancellableTask.perform(
                         data(
                             spec,
-                            responser: responser,
                             progress: progress,
                             requestModifier: requestModifier
                         ) { result in

--- a/Sources/Dyson/Dyson.swift
+++ b/Sources/Dyson/Dyson.swift
@@ -11,20 +11,16 @@ open class Dyson {
     // MARK: - Property
     private let provider: any NetworkProvider
     
-    public let responser: (any Responser)?
-    
     public let defaultHeaders: HTTPHeaders
     public let interceptors: [any Interceptor]
     
     // MARK: - Initializer
     public init(
         provider: any NetworkProvider,
-        responser: (any Responser)? = nil,
         defaultHeaders: HTTPHeaders = [:],
         interceptors: [any Interceptor] = []
     ) {
         self.provider = provider
-        self.responser = responser
         self.defaultHeaders = defaultHeaders
         self.interceptors = interceptors
     }
@@ -66,7 +62,6 @@ open class Dyson {
     @discardableResult
     open func data<S: Spec>(
         _ spec: S,
-        responser: (any Responser)? = nil,
         progress: ((Progress) -> Void)? = nil,
         requestModifier: ((URLRequest) -> URLRequest)? = nil,
         completion: @escaping (Result<S.Result, any Error>) -> Void
@@ -101,7 +96,6 @@ open class Dyson {
                 // Responser handle response.
                 self.response(
                     response,
-                    responser: responser ?? self.responser,
                     task: task,
                     spec: spec,
                     dyson: self,
@@ -263,15 +257,14 @@ open class Dyson {
     
     private func response<S: Spec>(
         _ response: Result<(Data, URLResponse), any Error>,
-        responser: (any Responser)?,
         task: ContainerSessionTask,
         spec: S,
         dyson: Dyson,
         interceptors: [any Interceptor],
         completion: @escaping (Result<S.Result, any Error>) -> Void
     ) {
-        guard let responser else {
-            completion(.failure(DysonError.responserNotRegistered))
+        guard let responser = spec.responser else {
+            completion(.failure(DysonError.responserDoseNotExist))
             return
         }
         

--- a/Sources/Dyson/Model/DysonError.swift
+++ b/Sources/Dyson/Model/DysonError.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum DysonError: Error {
-    case responserNotRegistered
+    case responserDoseNotExist
     case invalidURL
     case failedToParse(Error?)
     case failedToLoadData

--- a/Sources/Dyson/Request/QueryRequest.swift
+++ b/Sources/Dyson/Request/QueryRequest.swift
@@ -1,6 +1,6 @@
 //
 //  QueryRequest.swift
-//  
+//
 //
 //  Created by jsilver on 2022/01/16.
 //
@@ -10,10 +10,12 @@ import Foundation
 public struct QueryRequest: Request {
     // MARK: - Property
     private let parameter: [String: String]
+    private let isEncoded: Bool
     
     // MARK: - Initializer
-    public init(_ parameter: [String: String]) {
+    public init(_ parameter: [String: String], isEncoded: Bool = false) {
         self.parameter = parameter
+        self.isEncoded = isEncoded
     }
     
     // MARK: - Public
@@ -26,7 +28,11 @@ public struct QueryRequest: Request {
             throw DysonError.invalidURL
         }
         
-        components.queryItems = parameter.map { .init(name: $0, value: $1) }
+        if isEncoded {
+            components.percentEncodedQueryItems = parameter.map { .init(name: $0, value: $1) }
+        } else {
+            components.queryItems = parameter.map { .init(name: $0, value: $1) }
+        }
         
         guard let url = components.url else {
             throw DysonError.invalidURL
@@ -40,8 +46,9 @@ public struct QueryRequest: Request {
 
 public extension Request {
     static func query(
-        _ parameter: [String: String]
+        _ parameter: [String: String],
+        isEncoded: Bool = false
     ) -> Self where Self == QueryRequest {
-        QueryRequest(parameter)
+        QueryRequest(parameter, isEncoded: isEncoded)
     }
 }

--- a/Sources/Dyson/Spec/Spec.swift
+++ b/Sources/Dyson/Spec/Spec.swift
@@ -22,6 +22,8 @@ public protocol Spec {
     var headers: HTTPHeaders { get }
     
     var request: any Request { get }
+    var responser: (any Responser)? { get }
+    
     var result: Mapper<Result> { get }
     var error: Mapper<Error> { get }
 }

--- a/Tests/DysonTests/DysonTests.swift
+++ b/Tests/DysonTests/DysonTests.swift
@@ -26,8 +26,7 @@ final class DysonTests: XCTestCase {
                 dataTask: { request, completion in
                     completion(.success((data, .http(request, status: 200))))
                 }
-            ),
-            responser: .default
+            )
         )
         let spec = MockSpec<Empty, Empty, Empty>()
         
@@ -41,20 +40,24 @@ final class DysonTests: XCTestCase {
     func test_that_dyson_response_data_using_spec() async throws {
         // Given
         let person = Person(name: "dyson")
+        let json = """
+        {
+            "name": "dyson"
+        }
+        """
         
-        let jsonEncoder = JSONEncoder()
-        let data = try jsonEncoder.encode(person)
+        let data = json.data(using: .utf8) ?? Data()
         
         let sut = Dyson(
             provider: .mock(
                 dataTask: { request, completion in
                     completion(.success((data, .http(request, status: 200))))
                 }
-            ),
-            responser: .default
+            )
         )
         let spec = MockSpec<Empty, Person, Empty>(
-            result: .codable
+            responser: .default,
+            result: .codable()
         )
         
         // When
@@ -64,12 +67,15 @@ final class DysonTests: XCTestCase {
         XCTAssertEqual(response, person)
     }
     
-    func test_that_dyson_throw_error_when_response_data_without_responser() async throws {
-        // Give
-        let person = Person(name: "dyson")
+    func test_that_dyson_throw_error_when_spec_does_not_specifiy_responser() async throws {
+        // Given
+        let json = """
+        {
+            "name": "dyson"
+        }
+        """
         
-        let jsonEncoder = JSONEncoder()
-        let data = try jsonEncoder.encode(person)
+        let data = json.data(using: .utf8) ?? Data()
         
         let sut = Dyson(
             provider: .mock(
@@ -79,7 +85,7 @@ final class DysonTests: XCTestCase {
             )
         )
         let spec = MockSpec<Empty, Person, Empty>(
-            result: .codable
+            result: .codable()
         )
         
         // When
@@ -89,61 +95,5 @@ final class DysonTests: XCTestCase {
         } catch {
             
         }
-        
-        // Then
-    }
-    
-    func test_that_dyson_response_data_when_request_with_responser_even_if_responser_not_registered() async throws {
-        // Give
-        let person = Person(name: "dyson")
-        
-        let jsonEncoder = JSONEncoder()
-        let data = try jsonEncoder.encode(person)
-        
-        let sut = Dyson(
-            provider: .mock(
-                dataTask: { request, completion in
-                    completion(.success((data, .http(request, status: 200))))
-                }
-            )
-        )
-        let spec = MockSpec<Empty, Person, Empty>(
-            result: .codable
-        )
-        
-        // When
-        try await sut.data(spec, responser: .default)
-        
-        // Then
-    }
-    
-    func test_that_dyson_throw_error_when_response_data_even_if_responser_registered() async throws {
-        // Give
-        let person = Person(name: "dyson")
-        
-        let jsonEncoder = JSONEncoder()
-        let data = try jsonEncoder.encode(person)
-        
-        let sut = Dyson(
-            provider: .mock(
-                dataTask: { request, completion in
-                    completion(.success((data, .http(request, status: 200))))
-                }
-            ),
-            responser: .default
-        )
-        let spec = MockSpec<Empty, Person, Empty>(
-            result: .codable
-        )
-        
-        // When
-        do {
-            try await sut.data(spec, responser: .error(TestError(message: "error")))
-            XCTFail()
-        } catch {
-            
-        }
-        
-        // Then
     }
 }

--- a/Tests/DysonTests/EncoderTests.swift
+++ b/Tests/DysonTests/EncoderTests.swift
@@ -32,7 +32,7 @@ final class EncoderTests: XCTestCase {
     func test_that_codable_encoder_succeed_in_encoding_with_encodable_data() async throws {
         // Given
         let person = Person(name: "dyson")
-        let sut: Encoder<Person> = .codable
+        let sut: Encoder<Person> = .codable()
         
         // When
         let jsonEncoder = JSONEncoder()

--- a/Tests/DysonTests/Helper/Extension/XCTestCase+Helper.swift
+++ b/Tests/DysonTests/Helper/Extension/XCTestCase+Helper.swift
@@ -21,8 +21,7 @@ extension XCTestCase {
                 dataTask: dataTask,
                 uploadTask: uploadTask,
                 downloadTask: downloadTask
-            ),
-            responser: responser
+            )
         )
         
         return try await dyson.response(spec)

--- a/Tests/DysonTests/Helper/MockTarget.swift
+++ b/Tests/DysonTests/Helper/MockTarget.swift
@@ -18,6 +18,7 @@ struct MockSpec<Parameter, Result, Error: Swift.Error>: Spec {
     
     let headers: HTTPHeaders
     let request: Request
+    let responser: (any Responser)?
     
     let result: Mapper<Result>
     let error: Mapper<Error>
@@ -32,6 +33,7 @@ struct MockSpec<Parameter, Result, Error: Swift.Error>: Spec {
         transaction: Transaction = .data,
         headers: HTTPHeaders = [:],
         request: Request = .none,
+        responser: (any Responser)? = nil,
         result: Mapper<Result> = .none,
         error: Mapper<Error> = .none,
         parameter: Parameter = Empty()
@@ -42,6 +44,7 @@ struct MockSpec<Parameter, Result, Error: Swift.Error>: Spec {
         self.transaction = transaction
         self.headers = headers
         self.request = request
+        self.responser = responser
         self.result = result
         self.error = error
         self.parameter = parameter

--- a/Tests/DysonTests/InterceptorTests.swift
+++ b/Tests/DysonTests/InterceptorTests.swift
@@ -31,7 +31,6 @@ final class InterceptorTests: XCTestCase {
                     completion(.success((Data(), .http(request, status: 200))))
                 }
             ),
-            responser: .default,
             interceptors: [sut]
         )
         let spec = MockSpec<Empty, Empty, Empty>()
@@ -56,7 +55,6 @@ final class InterceptorTests: XCTestCase {
                     completion(.success((Data(), .http(request, status: 200))))
                 }
             ),
-            responser: .default,
             interceptors: [sut]
         )
         let spec = MockSpec<Empty, Empty, Empty>()

--- a/Tests/DysonTests/MapTests.swift
+++ b/Tests/DysonTests/MapTests.swift
@@ -35,7 +35,7 @@ final class MapperTests: XCTestCase {
         let jsonEncoder = JSONEncoder()
         let data = try jsonEncoder.encode(person)
         
-        let sut: Mapper<Person> = .codable
+        let sut: Mapper<Person> = .codable()
         
         // When
         let decodedData = try sut.map(data)
@@ -51,7 +51,7 @@ final class MapperTests: XCTestCase {
         let jsonEncoder = JSONEncoder()
         let data = try jsonEncoder.encode(coffee)
         
-        let sut: Mapper<Person> = .codable
+        let sut: Mapper<Person> = .codable()
         
         // When
         XCTAssertThrowsError(try sut.map(data))

--- a/Tests/DysonTests/RequestTests.swift
+++ b/Tests/DysonTests/RequestTests.swift
@@ -54,7 +54,7 @@ final class RequestTests: XCTestCase {
     func test_that_body_request_make_URLRequest_from_the_url_with_encodable_data() async throws {
         // Given
         let person = Person(name: "dyson")
-        let sut: any Request = .body(person, encoder: .codable)
+        let sut: any Request = .body(person, encoder: .codable())
         
         // When
         let jsonEncoder = JSONEncoder()

--- a/Tests/DysonTests/SpecTests.swift
+++ b/Tests/DysonTests/SpecTests.swift
@@ -113,6 +113,25 @@ final class SpecTests: XCTestCase {
         // Then
     }
     
+    func test_that_request_method_is_PATCH_as_specified_in_the_spec() async throws {
+        // Given
+        let sut = MockSpec<Empty, Empty, Empty>(
+            method: .patch
+        )
+        
+        // When
+        _ = try await request(
+            spec: sut,
+            dataTask: { request, completion in
+                XCTAssertEqual(request.httpMethod, "PATCH")
+                
+                completion(.success((Data(), .http(request, status: 200))))
+            }
+        )
+        
+        // Then
+    }
+    
     func test_that_request_header_contains_authorization_as_specified_in_the_spec() async throws {
         // Given
         let sut = MockSpec<Empty, Empty, Empty>(


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.



# 🔥 Cause
> If there is a reason, write why the code changes was occurred.



# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

### Added
- Added `isEncoded` parameter to the query request.
  - If it is set to `true`, query parameter doesn't percent encode automatically.

### Changed
- The `Responser` move to `Spec` from `Dyson`. Now you need to set `responser` to each spec.

### Fixed
- Fixed broken test cases.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.
